### PR TITLE
changed redirection method of home page

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,15 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  async redirects() {
+    return [
+      {
+        source: '/',
+        destination: '/hackrplay/2022/home',
+        permanent: false,
+      },
+    ]
+  },
+
   reactStrictMode: true,
   swcMinify: true,
   images: {

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,9 +1,5 @@
-import { useEffect } from "react";
-import { useRouter } from "next/router";
 import Layout from "@/components/Layout";
 
 export default function Home() {
-  const router = useRouter();
-
   return <Layout title="ReactPlay presents HACK-R-PLAY"></Layout>;
 }

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,12 +1,9 @@
-import { useEffect } from 'react';
-import { useRouter } from 'next/router';
-import Layout from '@/components/Layout';
+import { useEffect } from "react";
+import { useRouter } from "next/router";
+import Layout from "@/components/Layout";
 
 export default function Home() {
-	const router = useRouter();
-	useEffect(() => {
-		router.push('/hackrplay/2022/home');
-	}, []);
+  const router = useRouter();
 
-	return <Layout title='ReactPlay presents HACK-R-PLAY'></Layout>;
+  return <Layout title="ReactPlay presents HACK-R-PLAY"></Layout>;
 }


### PR DESCRIPTION
Changed the previous solution of redirecting the `/` route to `/hackrplay/2022/home` from using the `useEffect` hook to using the redirects api of Next.js

As a result of this, the flashing of the page at `/` is also resolved